### PR TITLE
[ERP-19] Sprint1 autologout

### DIFF
--- a/ERP/ERP/settings.py
+++ b/ERP/ERP/settings.py
@@ -130,6 +130,10 @@ USE_L10N = True
 
 USE_TZ = True
 
+# Auto logout after 30min
+SESSION_COOKIE_AGE = 1800
+# Refresh timer for every new request
+SESSION_SAVE_EVERY_REQUEST = True
 
 SETTINGS_PATH = os.path.dirname(os.path.dirname(__file__))
 


### PR DESCRIPTION
Auto logout logs the user after 30 min of inactivity. Activity is measured by page requests. Later release will include refreshing activity timer by measuring mouse movement.